### PR TITLE
Konfigurierbare Auswahl für Expertenbot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 .idea
 si/
 .env
+# Ignore all additional bots except for demo bot
+additional_bots/
+!additional_bots/botSdkDemo/

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
-# GovBot-SDK [![node: v6.11.x](https://img.shields.io/badge/node-v6.11.x-blue.svg)](https://nodejs.org/dist/latest-v6.x/) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](http://www.gnu.org/licenses/agpl-3.0) 
+# GovBot-SDK [![node: v6.11.x](https://img.shields.io/badge/node-v6.11.x-blue.svg)](https://nodejs.org/dist/latest-v6.x/) [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](http://www.gnu.org/licenses/agpl-3.0)
 Das GovBot-SDK stellt eine Entwicklungsumgebung für den [GovBot](https://www.govbot.io) bereit,  
 in der eigene Bot-Experten getestet und entwickelt werden können. Chatbots die mit diesem SDK entwickelt wurden können hinterher mit in den GovBot integriert werden.
 
 ## Installation und erster Start
-``` 
+```
 $ git clone https://github.com/GovBotIO/govbot-sdk.git
 $ cd govbot-sdk
-$ npm install 
+$ npm install
 $ mv .env.demo .env
-``` 
+```
 Das SDK wird mit folgendem Aufruf gestartet:
 ```
 $ node --debug app.js
 ```
+Mögliche Optionen können mit folgendem Aufruf angezeigt werden:
+```
+$ node --debug app.js -h
+```
 
 ## Entwicklungsbereich
 Der Expertenbot kann in "./additional_bots" analog zum "botSdkDemo" angelegt werden.
-Der Name des aktiven Bots wird in der ./app.js in Zeile 6 festgelegt und entspricht dem Ordnernamen unter "./additional_bots".  
+Der Pfad zum aktiven Bot kann über die Option `-b` konfiguriert werden.
+```
+$ node --debug app.js -b ./additional_bots/meinNeuerBot
+```
 
+Der Name des aktiven Bots entspricht dem Ordnernamen unter "./additional_bots". Wird die `-b` Option nicht verwendet, kommt der Bot "botSdkDemo" zum Einsatz.
 
 ## Entwickler-Tools
 #### BotFramework-Emulator ([Download](https://github.com/Microsoft/BotFramework-Emulator)):
-##### Konfiguration: 
+##### Konfiguration:
 - Bot Endpoint URL: `http://localhost:3978/msg`
 - App ID: -leer lassen-
 - App Password: -leer lassen-

--- a/app.js
+++ b/app.js
@@ -1,10 +1,33 @@
 var restify = require('restify');
 var builder = require('botbuilder');
 var config = {"variables": require('dotenv').config()};
+const path = require('path');
+const minimist = require('minimist');
 
 //=========================================================
-var aktivBot = 'botSdkDemo'; // Bot Name
+var defaultBotPath = './additional_bots/botSdkDemo'; // Bot path
 //=========================================================
+// Resolve cmd-line args and bot path
+
+const showHelp = function() {
+    console.log('Usage:');
+    console.log('');
+    console.log('    node [NODE_OPTS...] app.js [OPTIONS...]');
+    console.log('');
+    console.log('Optional arguments:');
+    console.log('');
+    console.log('    -b BOTPATH      Path to expert bot (default: ' +
+        defaultBotPath + ')');
+};
+const argv = minimist(process.argv.slice(2));
+if (argv.h !== undefined) {
+    showHelp();
+    process.exit(0);
+}
+var botPath = argv.b === undefined || argv.b == '' ? defaultBotPath : argv.b
+botPath = botPath.replace(/\/+$/, '') // Remove pending folder slashes
+var botName = path.basename(botPath);
+console.log('Active bot: ' + botName + ' @ ' + botPath);
 
 //=========================================================
 // Bot Setup
@@ -46,9 +69,9 @@ var botbuilder_logger = require('botbuilder/lib/logger');
 //=========================================================
 // SDK DemoBot include
 //=========================================================
-var aktiveBotModule = require('./additional_bots/' + aktivBot + '/main');
-console.log('Include ' +aktivBot + ' on ' + '/' + aktivBot);
-bot.dialog('/' + aktivBot , aktiveBotModule);
+var aktiveBotModule = require(botPath + '/main');
+console.log('Include ' +botName + ' on ' + '/' + botName);
+bot.dialog('/' + botName , aktiveBotModule);
 
 //=========================================================
 // Bots Dialogs
@@ -64,7 +87,7 @@ if (session.message.text == "--reset--") {
   } else {
     var chatMessage = session.message.text;
 
-    askExpert(aktivBot, session)
+    askExpert(botName, session)
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dotenv": "^2.0.0",
     "json-query": "^2.2.0",
     "jsonfile": "^2.4.0",
+    "minimist": "^1.2.0",
     "mstranslator": "^2.1.0",
     "request-promise": "^4.1.1",
     "restify": "^4.1.1",


### PR DESCRIPTION
Hey all, 

ich habe die app.js so erweitert, dass man nun über eine Kommandozeilen-Option `-b` den gewünschten Expertenbot auswählen kann. Wird die Option nicht verwendet, kommt wie bisher der botSdkDemo zum Einsatz. Die Auswahl über die Änderung einer Variable in app.js ist sehr umständlich und unüblich.

Als neue Dependency ist dafür [minimist](https://www.npmjs.com/package/minimist) hinzugekommen.
Die Doku habe ich entsprechend angepasst. 
Die `.gitignore` habe ich auch leicht angepasst, so dass es keinen git diff mehr gibt, wenn man neben dem botSdkDemo weitere Ordnerpfade anlegt. 

Gruß Basti.